### PR TITLE
管理者ログイン後遷移先変更

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -9,10 +9,10 @@ class Admin::GenresController < ApplicationController
   def create
     @genre = Genre.new(genre_params)
     if @genre.save
-      @genres = Genre.all
+      @genres = Genre.page(params[:page]).per(5)
       redirect_to admin_genres_path, notice: "ジャンル登録完了"
     else
-      @genres = Genre.all
+      @genres = Genre.page(params[:page]).per(5)
       render :index
     end
   end
@@ -23,8 +23,11 @@ class Admin::GenresController < ApplicationController
 
   def update
     @genre = Genre.find(params[:id])
-    @genre.update(genre_params)
-    redirect_to admin_genres_path
+    if @genre.update(genre_params)
+      redirect_to admin_genres_path
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -26,7 +26,7 @@ class Admin::SessionsController < Devise::SessionsController
   # end
 
   def after_sign_in_path_for(resource)
-    about_path
+    admin_users_path
   end
 
   def after_sign_out_path_for(resource)

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,4 +1,6 @@
 class Genre < ApplicationRecord
 
   has_many :posts
+
+  validates :name, presence: true
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -6,6 +6,10 @@
         <h2 class="text-user">ジャンル名編集</h2>
       </div>
 
+      <div class="row mt-3 d-flex justify-content-center">
+        <%= render "public/shared/error_messages", model: @genre %>
+      </div>
+
       <%= form_with model: @genre, url: admin_genre_path, method: :patch do |f| %>
         <div class="form-group row d-flex justify-content-center mt-5">
           <div class="col-sm-6">

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -6,6 +6,10 @@
         <h2 class="text-user">ジャンル一覧・追加</h2>
       </div>
 
+      <div class="row mt-3 d-flex justify-content-center">
+        <%= render "public/shared/error_messages", model: @genre %>
+      </div>
+
       <%= form_with model: @genre, url: admin_genres_path do |f| %>
         <div class="form-group row mt-3">
           <div class="col-lg-9  d-flex justify-content-end">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -27,7 +27,9 @@
         </tbody>
       </table>
       <div class="d-flex justify-content-center mt-5">
-        <%= link_to "退会", admin_user_path(@user.id), class: "btn btn-danger btn-custom", method: :delete, "data-confirm" => "本当にこのユーザーを退会させますか？" %>
+        <% unless @user.email == "guest@example.com" then %>
+          <%= link_to "退会", admin_user_path(@user.id), class: "btn btn-danger btn-custom", method: :delete, "data-confirm" => "本当にこのユーザーを退会させますか？" %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
・管理者ログイン後遷移先を About → ユーザー一覧　に変更
・ジャンル登録、編集に空欄のバリデーション追加
・↑該当ページにエラーメッセージ表示