### PR TITLE
レイアウトエラー修正

### DIFF
--- a/app/assets/stylesheets/add_styles.css
+++ b/app/assets/stylesheets/add_styles.css
@@ -5,6 +5,7 @@
   color: #6c6b6b;
 }
 
+/* 投稿詳細内用テキスト設定 */
 h4, h5 {
   width: 100%;
   word-wrap: break-word;
@@ -12,6 +13,14 @@ h4, h5 {
   word-break: break-word;
 }
 
+/* ユーザー詳細内テーブル */
+.table-us {
+  width: 50%;
+  margin: auto;
+  table-layout: fixed;
+}
+
+/* コメント表示 */
 #comments {
   width: 100%;
   max-width: 100%;
@@ -19,6 +28,7 @@ h4, h5 {
   overflow-wrap: break-word;
 }
 
+/* DMテキスト表示設定 */
 .message-container .message-style {
   word-wrap: break-word;
   overflow-wrap: break-word;
@@ -130,10 +140,12 @@ footer {
   width: 10em;
 }
 
+/* 投稿フォーム */
 .form-post {
   min-width: 15em;
 }
 
+/* 投稿本文フォーム */
 .form-b {
   min-height: 10em;
 }
@@ -142,6 +154,7 @@ footer {
   background-color: #cb565b;
 }
 
+/* マイページ内投稿一覧テーブル */
 .table-u {
   min-height: 20em;
   width: 100%;
@@ -196,6 +209,7 @@ footer {
   transform: translateY(-1px);
 }
 
+/* グループ機能テーブル */
 .table-group {
   table-layout: fixed;
   width: 100%;
@@ -241,11 +255,13 @@ footer {
   box-shadow: none;
 }
 
+/* 通知一覧 */
 .notification-list {
   list-style-type: none;
   padding: 0;
 }
 
+/* 通知表示 */
 .notification-item {
   font-weight: bold;
   background: #ffe0e1;
@@ -255,10 +271,12 @@ footer {
   transition: background 0.3s ease;
 }
 
+/* 通知一覧文字 */
 .notification-text {
   color: rgb(0, 128, 255);
 }
 
+/* 通知ベル */
 .fa-bell {
   color: gray; /* 通常は灰色 */
   position: relative;
@@ -266,14 +284,14 @@ footer {
 }
 
 .fa-bell.bell-notified {
-  color: yellow;
+  color: yellow; /* 通知があると黄色 */
 }
-
+黄
 .genre-text {
   color: rgb(105, 105, 105);
 }
 
-
+/* ゲストログインボタン */
 .btn-guest {
 	display: block;
 	text-align: center;
@@ -310,7 +328,22 @@ footer {
 }
 
 .text-red {
-  color: #b7282e; /* 色を赤にする */
+  color: #b7282e;
+}
+
+/* エラーメッセージ設定 */
+.error-messages {
+  max-width: 100%;
+  margin-left: 2em;
+}
+
+ /* DM一覧名前表示 */
+.message-name {
+  display: inline-block;
+  max-width: 120px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 @media (max-width: 768px) {

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -8,6 +8,7 @@ class Admin::CommentsController < ApplicationController
   def destroy
     @comment = Comment.find(params[:id])
     @comment.destroy
+    flash[:notice] = 'コメント削除完了'
     redirect_to admin_comments_path
   end
 end

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -24,6 +24,7 @@ class Admin::GenresController < ApplicationController
   def update
     @genre = Genre.find(params[:id])
     if @genre.update(genre_params)
+      flash[:notice] = 'ジャンル編集完了'
       redirect_to admin_genres_path
     else
       render :edit
@@ -33,6 +34,7 @@ class Admin::GenresController < ApplicationController
   def destroy
     @genre = Genre.find(params[:id])
     @genre.destroy
+    flash[:notice] = 'ジャンル削除完了'
     redirect_to admin_genres_path
   end
 

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -7,6 +7,7 @@ class Admin::GroupsController < ApplicationController
   def destroy
     @group = Group.find(params[:id])
     @group.destroy
+    flash[:notice] = 'グループ削除完了'
     redirect_to admin_groups_path
   end
 end

--- a/app/controllers/public/groups_controller.rb
+++ b/app/controllers/public/groups_controller.rb
@@ -16,6 +16,7 @@ class Public::GroupsController < ApplicationController
     @group.owner_id = current_user.id
     if @group.save
       GroupUser.create(user_id: current_user.id, group_id: @group.id)
+      flash[:notice] = 'Group created successfully'
       redirect_to groups_path, method: :post
     else
       @groups = Group.page(params[:page]).per(7)
@@ -28,6 +29,7 @@ class Public::GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
+      flash[:notice] = 'Group edited successfully'
       redirect_to group_path(@group.id)
     else
       render :edit
@@ -36,6 +38,7 @@ class Public::GroupsController < ApplicationController
 
   def destroy
     @group.destroy
+    flash[:notice] = 'Group deleted successfully'
     redirect_to groups_path
   end
 

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -10,6 +10,7 @@ class Public::PostsController < ApplicationController
     @post = Post.new(post_params)
     @post.user_id = current_user.id
     if @post.save
+      flash[:notice] = 'Post created successfully'
       redirect_to post_path(@post.id)
     else
       render :new
@@ -30,6 +31,7 @@ class Public::PostsController < ApplicationController
 
   def update
     if @post.update(post_params)
+      flash[:notice] = 'Post edited successfully'
       redirect_to post_path(@post.id)
     else
       render :edit
@@ -38,6 +40,7 @@ class Public::PostsController < ApplicationController
 
   def destroy
     @post.destroy
+    flash[:notice] = 'Post deleted successfully'
     redirect_to mypage_users_path
   end
 

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -12,6 +12,7 @@ class Public::UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
+      flash[:notice] = 'User information edited successfully'
       redirect_to mypage_users_path
     else
       render :edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
   has_one_attached :profile_image
 
-  validates :name, length: {minimum:2,maximum:20}
+  validates :name, length: {minimum:2,maximum:15}
   validates :introduction, length: {maximum:235}
   validates :native, presence: true, length: {maximum:30}
 

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -15,9 +15,11 @@
           <div>
             <h2 class="text-user text-center mb-3">Recent Updates</h2>
           </div>
-          <table class="table">
-            <%= render 'public/posts/list', posts: @posts %>
-          </table>
+          <div class="table-responsive">
+            <table class="table">
+              <%= render 'public/posts/list', posts: @posts %>
+            </table>
+          </div>
           <div class="d-flex justify-content-end">
             <%= link_to "Check more >>", posts_path %>
           </div> 

--- a/app/views/public/messages/index.html.erb
+++ b/app/views/public/messages/index.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="row">
-    <table class="table">
+    <table class="table table-meg">
       <tbody>
         <% @rooms.each do |room| %>
           <% partner = room.users.where.not(id: current_user.id).first %>
@@ -19,7 +19,7 @@
                     <%= image_tag 'icon_user_5.png', size: "70x70" %>
                   <% end %>
                   <br>
-                  <div class="text-dark"><%= partner.name %></div>
+                  <div class="message-name text-dark"><%= partner.name %></div>
                 <% end %>
               <% else %>
                 <p>Unknown User</p>

--- a/app/views/public/posts/edit.html.erb
+++ b/app/views/public/posts/edit.html.erb
@@ -15,7 +15,7 @@
           <div class="col-2 my-auto mr-4">
             <%= f.label :genre_id, 'Genre' %>
           </div>
-          <div class="col-9 form-post">
+          <div class="col-md-9 form-post">
             <%= f.collection_select :genre_id, Genre.all, :id, :name, {}, {class: 'form-control'} %>
           </div>
         </div>
@@ -24,7 +24,7 @@
           <div class="col-2 mr-4 my-auto">
             <%= f.label :title %>
           </div>
-          <div class="col-9">
+          <div class="col-md-9">
             <%= f.text_field :title, class: "form-control form-post" %>
           </div>
         </div>
@@ -33,7 +33,7 @@
           <div class="col-2 mr-4 my-auto">
             <%= f.label :body %>
           </div>
-          <div class="col-9">
+          <div class="col-md-9">
             <%= f.text_area :body, class: "form-control form-post form-b" %>
           </div>
         </div>

--- a/app/views/public/shared/_error_messages.html.erb
+++ b/app/views/public/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if model.errors.any? %>
-  <ul>
+  <ul class="error-messages">
     <% model.errors.full_messages.each do |message| %>
       <li><%= message %></li>
     <% end %>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -9,7 +9,7 @@
           <%= image_tag 'icon_user_5.png', size: "100x100" %>
         <% end %>
       </div>
-      <table class="table d-flex justify-content-center">
+      <table class="table table-us d-flex justify-content-center">
         <tbody>
           <tr>
             <th>Name</th>


### PR DESCRIPTION
・ユーザー詳細内テーブルwidth狭く
・各動作にflashメッセージ追加
・Topページ新規投稿テーブルのレスポンシブ対応
・DM一覧ユーザー名部分短く表示するよう設定
・投稿編集画面フォームをレスポンシブ対応
・エラーメッセージ表示場所見やすく調整