### PR TITLE
マージン調節

### DIFF
--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <div class="row mx-auto">
     <h2 class="text-user mb-4">コメント一覧</h2>
 

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <div class="row mx-auto">
     <h2 class="text-user mb-4">グループ一覧</h2>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <div class="row mx-auto">
     <h2 class="text-user mb-4">ユーザー一覧</h2>
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <div class="row">
 
     <div class="col-md-12">

--- a/app/views/public/searches/search.html.erb
+++ b/app/views/public/searches/search.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
 
   <div class="mb-5">
     <h2 class="text-center text-user">Search results</h2>


### PR DESCRIPTION
フラッシュメッセージ用空間を常時表示ではなくした影響で、レイアウトが崩れてしまったページにmt-5挿入
(管理者: コメント一覧, グループ一覧, ユーザー一覧, ユーザー詳細 / 会員: 検索結果一覧) 