### PR TITLE
通知自動削除機能実装

### DIFF
--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -5,6 +5,19 @@ class Public::NotificationsController < ApplicationController
     @notifications = current_user.passive_notifications
   end
 
+  def destroy
+    @notification = Notification.find(params[:id])
+    @notification.destroy
+
+    case @notification.action
+    when "dm"
+      message = Message.find_by(id: @notification.message_id)
+      redirect_to message_path(message.user_id)
+    when "comment"
+      redirect_to post_path(@notification.comment.post_id)
+    end
+  end
+
   def destroy_all
     current_user.passive_notifications.destroy_all
     redirect_to notifications_path, notice: "All notifications have been deleted."

--- a/app/views/public/groups/permits.html.erb
+++ b/app/views/public/groups/permits.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <h2 class="text-user text-center">Pending Users</h2>
   <h4 class="col-lg-5 mt-4 mx-auto text-center">Group name:　<%= @group.name %></h4>
 

--- a/app/views/public/messages/index.html.erb
+++ b/app/views/public/messages/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <div class="row d-flex justify-content-center mb-3">
     <h2 class="text-center text-user">Private Messages</h2>
   </div>

--- a/app/views/public/messages/show.html.erb
+++ b/app/views/public/messages/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <div class="row d-flex justify-content-center">
     <h2 id="room" data-room="<%= @room.id %>" data-user="<%= current_user.id %>" class="text-user text-center mb-5">Direct Message with <%= @user.name %></h2>
   </div>

--- a/app/views/public/notifications/index.html.erb
+++ b/app/views/public/notifications/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-5">
   <h2 class="text-user text-center">Notifications</h2>
 
   <%= link_to "Delete all", destroy_all_notifications_path, method: :delete, remote: true, class: "btn btn-danger mb-4", "data-confirm" => "Are you sure you want to delete all the notifications?" %>
@@ -10,12 +10,12 @@
           <% if notification.action == "dm" %>
             <% message = Message.find_by(id: notification.message_id) %>
             <% if message %>
-              <%= link_to "#{notification.visitor.name} sent you a message (#{time_ago_in_words(notification.created_at)} ago)", message_path(message.user_id), class: "notification-text" %>
+              <%= link_to "#{notification.visitor.name} sent you a message (#{time_ago_in_words(notification.created_at)} ago)", notification_path(notification), method: :delete, class: "notification-text" %>
             <% end %>
           <% elsif notification.action == "group_request" %>
             <%= link_to "#{notification.visitor.name} requested to join the group (#{time_ago_in_words(notification.created_at)} ago)", permits_path(notification.permit.group_id), class: "notification-text" %>
           <% elsif notification.action == "comment" %>
-            <%= link_to "#{notification.visitor.name} commented on your post (#{time_ago_in_words(notification.created_at)} ago)", post_path(notification.comment.post_id), class: "notification-text" %>
+            <%= link_to "#{notification.visitor.name} commented on your post (#{time_ago_in_words(notification.created_at)} ago)", notification_path(notification), method: :delete, class: "notification-text" %>
           <% end %>
         </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
       resource :permits, only: [:create, :destroy]
     end
     resources :messages, only: [:show, :index, :create, :destroy]
-    resources :notifications, only: [:index] do
+    resources :notifications, only: [:index, :destroy] do
       collection do
         delete 'destroy_all'
       end

--- a/db/migrate/20250312093405_remove_post_status_from_posts.rb
+++ b/db/migrate/20250312093405_remove_post_status_from_posts.rb
@@ -1,0 +1,5 @@
+class RemovePostStatusFromPosts < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :posts, :post_status, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_20_170734) do
+ActiveRecord::Schema.define(version: 2025_03_12_093405) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -123,7 +123,6 @@ ActiveRecord::Schema.define(version: 2025_02_20_170734) do
     t.integer "genre_id", null: false
     t.string "title", null: false
     t.text "body", null: false
-    t.boolean "post_status", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
・通知一覧よりDM、コメントの通知を押下すると、対象画面に遷移時にその通知を自動削除するよう設定
・マージン調整(DM一覧・詳細, グループ承認待ち一覧)
・postsテーブルから使用予定のないカラムの削除(post_status)